### PR TITLE
Make move-cell no-std.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "movecell"
 version = "0.2.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
+edition = "2018"
 license = "Apache-2.0 / MIT"
 repository = "https://github.com/SimonSapin/rust-movecell"
 description = "`std::cell::Cell` for not-implicitly-copyable types."


### PR DESCRIPTION
* Breaking Change *

* Changes:

- Make move-cell no-std.
- Fix self-comparison.
- Bump edition to 2018.

* Motivation:

There is no reason for move-cell to depend on std, so it would be great
if it were possible to use it in no-std crates.

To make the move easier, raise the edition so that "core" is found even
in `std` mode -- when compiling for tests. This is a breaking change.

Drive-by fix equality self-comparison. It's otherwise somewhat
surprising -- though maybe it shouldn't be. This is a breaking change.